### PR TITLE
すでにいいねのアクションがある研究室を除かないように変更

### DIFF
--- a/backend/graph/service/laboratory.go
+++ b/backend/graph/service/laboratory.go
@@ -39,12 +39,11 @@ func (ls *laboratoryService) GetLaboratoryById(id string) (*model.Laboratory, er
 }
 
 func (ls *laboratoryService) GetMatchableLaboratories(studentId string) ([]*model.Laboratory, error) {
-	// すでにいいねのアクションがある(非NULLかつBLANKでない)研究室は除く
 	var excludedLaboratoryIds []int
 	err := ls.db.Table("student_laboratories").
 		Select("DISTINCT laboratory_id").
 		Where("student_id = ?", studentId).
-		Where("status IS NOT NULL AND status <> ?", model.LikeStatusBlank).
+		// Where("status IS NOT NULL AND status <> ?", model.LikeStatusBlank).
 		Pluck("laboratory_id", &excludedLaboratoryIds).Error
 	if err != nil {
 		fmt.Println("GetMatchableLaboratories failed: cannot get laboratoryIds", err)


### PR DESCRIPTION
- フロント側で，ある研究室にいいねをつけた後，研究室ページ一覧をリロードするといいねをつけた研究室が表示されないという報告があった
- すでにいいねのアクションがある研究室を除く処理があったのでその処理を行わないように変更